### PR TITLE
Fix date format for Safari

### DIFF
--- a/_layouts/banner.html
+++ b/_layouts/banner.html
@@ -22,8 +22,8 @@
 
             // hide banner if it's not time to show it.
             {% if page.start_time or page.end_time %}
-                const startTime = new Date('{{page.start_time | default: "1970-01-01"}}');
-                const endTime = new Date('{{page.end_time | default: "2099-12-31"}}');
+                const startTime = new Date('{{page.start_time | date: "%Y-%m-%dT%H:%M:%S%z" | default: "1970-01-01"}}');
+                const endTime = new Date('{{page.end_time | date: "%Y-%m-%dT%H:%M:%S%z" | default: "2099-12-31"}}');
                 console.log(startTime);
                 console.log(endTime);
                 const now = new Date();


### PR DESCRIPTION
Safari doesn't like the default date format passed by Liquid. This sets a date format that works in Safari and other browsers.